### PR TITLE
Fix issue where preflight errors were not caught

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -53,7 +53,7 @@ export default class Http {
         reject({
           body: { error: { message: 'An unknown error occurred during the request.' } },
           status: request.status
-        });
+        })
       }
       request.setRequestHeader('Content-Type', 'application/json')
       request.setRequestHeader('Accept', 'application/json')

--- a/src/http.js
+++ b/src/http.js
@@ -49,6 +49,12 @@ export default class Http {
           })
         }
       }
+      request.onerror = function () {
+        reject({
+          body: { error: { message: 'An unknown error occurred during the request.' } },
+          status: request.status
+        });
+      }
       request.setRequestHeader('Content-Type', 'application/json')
       request.setRequestHeader('Accept', 'application/json')
       request.send(JSON.stringify(data))


### PR DESCRIPTION
@lucascosta The sdk does not seem to work properly if the preflight response is a HTTP error. An example is when the token you use have been invalidated, e.g. if the user changed password or revoked access for your app to their Facebook data.

By the look of it, it seem like the `XMLHttpRequest.onload` is not triggered if there is an error in the preflight request. Since this is the case then the token has been invalidated (an HTTP error 400 is returned from the preflight by Facebook), the promise is never resolved or rejected and the only error displayed is the on the browser outputs to the console.

I think adding an `XMLHttpRequest.onerror` and reject the promise from there as well might solve this.