### PR TITLE
fix: Update example in README.md with current Campaign.DatePreset value

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ const Campaign = adsSdk.Campaign
 
 const account = new AdAccount({ 'id': accountId })
 const insightsFields = ['impressions', 'frequency', 'unique_clicks', 'actions', 'spend', 'cpc']
-const insightsParams = { date_preset: Campaign.DatePreset.last_90_days }
+const insightsParams = { date_preset: Campaign.DatePreset.last_90d }
 var campaigns
 
 account.read([AdAccount.Fields.name])


### PR DESCRIPTION
`README.md` is using an outdated Campaign.DatePreset value; this updates `README.md`.