### PR TITLE
fix: Replaced lingering instances of "Fields" with "Field"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ const insightsFields = ['impressions', 'frequency', 'unique_clicks', 'actions', 
 const insightsParams = { date_preset: Campaign.DatePreset.last_90d }
 var campaigns
 
-account.read([AdAccount.Fields.name])
+account.read([AdAccount.Field.name])
   .then((account) => {
     account.getInsights(insightsFields, insightsParams)
       .then((actInsights) => console.log(account, actInsights))
       .catch(console.error)
-    return account.getCampaigns([Campaign.Fields.name], { limit: 10 }) // fields array and params
+    return account.getCampaigns([Campaign.Field.name], { limit: 10 }) // fields array and params
   })
   .then((result) => {
     campaigns = result
@@ -86,7 +86,7 @@ console.log(account.id) // fields can be accessed as properties
 
 #### CRUD operations
 
-Most of Facebook's Objects can perform Create, Read, Update, and Delete operations. Enums such as `Fields` and other constants are provided by the classes to improve maintainability.
+Most of Facebook's Objects can perform Create, Read, Update, and Delete operations. Enums such as `Field` and other constants are provided by the classes to improve maintainability.
 
 ##### Create
 
@@ -94,8 +94,8 @@ Most of Facebook's Objects can perform Create, Read, Update, and Delete operatio
 const Campaign = require('facebook-ads-sdk').Campaign;
 const accountId = 'AD_ACCOUNT_ID'
 const data = {
-  [Campaign.Fields.name]: 'Campaign Name',
-  [Campaign.Fields.status]: Campaign.Status.paused
+  [Campaign.Field.name]: 'Campaign Name',
+  [Campaign.Field.status]: Campaign.Status.paused
 }
 new Campaign(data, accountId) // set data and parent ID on instantiation
   .create()
@@ -109,7 +109,7 @@ new Campaign(data, accountId) // set data and parent ID on instantiation
 const Campaign = require('facebook-ads-sdk').Campaign;
 const campaignId = 'CAMPAIGN_ID'
 new Campaign({ 'id': campaignId })
-  .read([Campaign.Fields.name]) // fields array
+  .read([Campaign.Field.name]) // fields array
   .then((campaign) => { console.log(campaign.name) })
   .catch(errorFunction)
 ```
@@ -129,7 +129,7 @@ Campaign.getByIds(campaignIds)
 const Campaign = require('facebook-ads-sdk').Campaign;
 const campaignId = 'CAMPAIGN_ID'
 const newName = 'New Campaign Name'
-new Campaign({ [Campaign.Fields.id]: campaignId, [Campaign.Fields.name]: newName })
+new Campaign({ [Campaign.Field.id]: campaignId, [Campaign.Field.name]: newName })
   .udpate()
   .then((result) => { console.log(result.success) })
   .catch(errorFunction)
@@ -155,7 +155,7 @@ Here's an example suposing we have currently 17 campaigns in an Ad Account:
 ```javascript
 const AdAccount = require('facebook-ads-sdk').AdAccount;
 const account = new AdAccount({'id': 'AD_ACCOUNT_ID'})
-account.getCampaigns([Campaign.Fields.name], { limit: 10 }) // fields array and params
+account.getCampaigns([Campaign.Field.name], { limit: 10 }) // fields array and params
 .then((campaigns) => {
   console.log(campaigns.length) // 10
   console.log(campaigns.hasNext()) // true

--- a/src/core.js
+++ b/src/core.js
@@ -8,10 +8,10 @@ export class AbstractObject {
 
   constructor () {
     this._data = {}
-    if (this.constructor.Fields === undefined) {
-      throw new Error('A "Fields" frozen object must be defined in the object class')
+    if (this.constructor.Field === undefined) {
+      throw new Error('A "Field" frozen object must be defined in the object class')
     }
-    this._fields = Object.keys(this.constructor.Fields)
+    this._fields = Object.keys(this.constructor.Field)
     this._fields.forEach((field) => {
       this._defineProperty(field)
     })

--- a/src/objects/adaccountroas.js
+++ b/src/objects/adaccountroas.js
@@ -35,39 +35,4 @@ export default class AdAccountRoas extends AbstractObject {
       yield_90d: 'yield_90d'
     })
   }
-
-  static get Fields () {
-    return Object.freeze({
-      adgroup_id: 'adgroup_id',
-      arpu_180d: 'arpu_180d',
-      arpu_1d: 'arpu_1d',
-      arpu_30d: 'arpu_30d',
-      arpu_365d: 'arpu_365d',
-      arpu_3d: 'arpu_3d',
-      arpu_7d: 'arpu_7d',
-      arpu_90d: 'arpu_90d',
-      campaign_group_id: 'campaign_group_id',
-      campaign_id: 'campaign_id',
-      date_start: 'date_start',
-      date_stop: 'date_stop',
-      installs: 'installs',
-      revenue: 'revenue',
-      revenue_180d: 'revenue_180d',
-      revenue_1d: 'revenue_1d',
-      revenue_30d: 'revenue_30d',
-      revenue_365d: 'revenue_365d',
-      revenue_3d: 'revenue_3d',
-      revenue_7d: 'revenue_7d',
-      revenue_90d: 'revenue_90d',
-      spend: 'spend',
-      yield_180d: 'yield_180d',
-      yield_1d: 'yield_1d',
-      yield_30d: 'yield_30d',
-      yield_365d: 'yield_365d',
-      yield_3d: 'yield_3d',
-      yield_7d: 'yield_7d',
-      yield_90d: 'yield_90d'
-    })
-  }
-
 }

--- a/src/objects/customaudience.js
+++ b/src/objects/customaudience.js
@@ -81,32 +81,6 @@ export default class CustomAudience extends AbstractCrudObject {
     })
   }
 
-  static get Fields () {
-    return Object.freeze({
-      account_id: 'account_id',
-      approximate_count: 'approximate_count',
-      data_source: 'data_source',
-      delivery_status: 'delivery_status',
-      description: 'description',
-      external_event_source: 'external_event_source',
-      id: 'id',
-      is_value_based: 'is_value_based',
-      lookalike_audience_ids: 'lookalike_audience_ids',
-      lookalike_spec: 'lookalike_spec',
-      name: 'name',
-      operation_status: 'operation_status',
-      opt_out_link: 'opt_out_link',
-      permission_for_actions: 'permission_for_actions',
-      pixel_id: 'pixel_id',
-      retention_days: 'retention_days',
-      rule: 'rule',
-      subtype: 'subtype',
-      time_content_updated: 'time_content_updated',
-      time_created: 'time_created',
-      time_updated: 'time_updated'
-    })
-  }
-
   static getEndpoint () {
     return 'customaudiences'
   }

--- a/test/integration/test-integration.js
+++ b/test/integration/test-integration.js
@@ -35,7 +35,7 @@ describe('Graph Objects', function () {
 
   it('should be read', (done) => {
     account = new AdAccount({'id': accountId})
-    account.read([AdAccount.Fields.id, AdAccount.Fields.name])
+    account.read([AdAccount.Field.id, AdAccount.Field.name])
       .then(() => {
         account.name.should.be.ok
         done()
@@ -45,9 +45,9 @@ describe('Graph Objects', function () {
 
   it('should be created', (done) => {
     const data = {
-      [Campaign.Fields.name]: 'Facebook JS Ads SDK Test',
-      [Campaign.Fields.objective]: Campaign.Objective.link_clicks,
-      [Campaign.Fields.status]: Campaign.Status.paused
+      [Campaign.Field.name]: 'Facebook JS Ads SDK Test',
+      [Campaign.Field.objective]: Campaign.Objective.link_clicks,
+      [Campaign.Field.status]: Campaign.Status.paused
     }
     new Campaign(data, accountId).save()
       .then((result) => {
@@ -69,7 +69,7 @@ describe('Graph Objects', function () {
   })
 
   it('should read their related objects', (done) => {
-    account.getCampaigns([Campaign.Fields.name])
+    account.getCampaigns([Campaign.Field.name])
       .then((campaigns) => {
         campaigns.should.be.a('array').and.have.length.above(0)
         campaigns[0].should.be.an.instanceof(Campaign)
@@ -101,9 +101,9 @@ describe('Graph Objects', function () {
   it('should paginate edges', (done) => {
     var campaigns
     const data = {
-      [Campaign.Fields.name]: 'Facebook JS Ads SDK Test',
-      [Campaign.Fields.objective]: Campaign.Objective.link_clicks,
-      [Campaign.Fields.status]: Campaign.Status.paused
+      [Campaign.Field.name]: 'Facebook JS Ads SDK Test',
+      [Campaign.Field.objective]: Campaign.Objective.link_clicks,
+      [Campaign.Field.status]: Campaign.Status.paused
     }
     Promise.all([new Campaign(data, accountId).save(), new Campaign(data, accountId).save()])
       .then((result) => {

--- a/test/src/test-core.js
+++ b/test/src/test-core.js
@@ -4,14 +4,14 @@ chai.should()
 
 describe('AbstractObject', () => {
   class ConcreteObject extends AbstractObject {
-    static get Fields () { return Object.freeze({ field: 'field' }) }
+    static get Field () { return Object.freeze({ field: 'field' }) }
   }
 
-  it('should possess a Fields enum', () => {
+  it('should possess a Field enum', () => {
     ;() => (new AbstractObject()).should.throw(Error)
-    ;() => (ConcreteObject.Fields = {}).should.throw(TypeError)
-    ;() => (ConcreteObject.Fields.field = '').should.throw(TypeError)
-    ConcreteObject.Fields.field.should.be.equal('field')
+    ;() => (ConcreteObject.Field = {}).should.throw(TypeError)
+    ;() => (ConcreteObject.Field.field = '').should.throw(TypeError)
+    ConcreteObject.Field.field.should.be.equal('field')
   })
 
   it('should create a data object with getters and setters for fields', () => {
@@ -67,7 +67,7 @@ describe('AbstractObject', () => {
 
 describe('AbstractCrudObject', () => {
   class ConcreteCrudObject extends AbstractCrudObject {
-    static get Fields () { return Object.freeze({ field: 'field', anotherfield: 'anotherfield' }) }
+    static get Field () { return Object.freeze({ field: 'field', anotherfield: 'anotherfield' }) }
   }
 
   it('should store changes for field properties', () => {
@@ -137,7 +137,7 @@ describe('Cursor', () => {
   const sourceObject = { getId: () => 'id', getApi: () => ({call: callStub}) }
   class targetClass {
     constructor (num) { this.v = num }
-    static get Fields () {}
+    static get Field () {}
     static getEndpoint () { 'endpoint' }
   }
 


### PR DESCRIPTION
In the v2.9 -> v2.10 conversion, all instances of "Fields" were replaced with "Field", but a few managed to slip through. I _think_ this catches and fixes the remainder, but I'm not 100% sure. @lucascosta? Did I miss any?