### PR TITLE
AdsInsights weren't being parsed properly in v2.10

### DIFF
--- a/src/objects/adsinsights.js
+++ b/src/objects/adsinsights.js
@@ -1,6 +1,6 @@
 import { AbstractObject } from './../core'
 
-export default class AdsInsights extends AbstractObject {
+export default class AdsInsights extends AbstractCrudObject {
 
   static get Field () {
     return Object.freeze({

--- a/src/objects/adsinsights.js
+++ b/src/objects/adsinsights.js
@@ -1,4 +1,4 @@
-import { AbstractObject } from './../core'
+import { AbstractCrudObject } from './../core'
 
 export default class AdsInsights extends AbstractCrudObject {
 


### PR DESCRIPTION
When using `getInsights` on an `AdAccount`, `AdsInsights` weren't resolving properly due to them being an AbstractClass instead of an AbstractCrudClass.

I'm honestly not sure if it's meant to be an AbstractCrudObject, but at least this is functioning for us now.